### PR TITLE
feat: LanguageTool spell-check integration

### DIFF
--- a/src-tauri/src/credential_manager.rs
+++ b/src-tauri/src/credential_manager.rs
@@ -4,7 +4,6 @@ use tauri::{command, AppHandle};
 
 // Service names for different credential types
 const LANGUAGETOOL_SERVICE: &str = "jot.languagetool";
-const DEEPL_SERVICE: &str = "jot.deepl";
 const CHATGPT_SERVICE: &str = "jot.chatgpt";
 
 // Helper function to create a keyring entry with consistent naming
@@ -94,29 +93,6 @@ pub fn get_languagetool_credential(username: String) -> Result<String, String> {
 #[command]
 pub fn has_languagetool_credential(username: String) -> bool {
     match get_credential(LANGUAGETOOL_SERVICE, &username) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
-}
-
-#[command]
-pub fn store_deepl_credential(app_handle: AppHandle, api_key: String) -> Result<(), String> {
-    // For services that don't have a username, we use a consistent identifier
-    // Including the app handle info to make it unique per installation
-    let app_id = app_handle.config().identifier.clone();
-    store_credential(DEEPL_SERVICE, &app_id, &api_key)
-}
-
-#[command]
-pub fn get_deepl_credential(app_handle: AppHandle) -> Result<String, String> {
-    let app_id = app_handle.config().identifier.clone();
-    get_credential(DEEPL_SERVICE, &app_id)
-}
-
-#[command]
-pub fn has_deepl_credential(app_handle: AppHandle) -> bool {
-    let app_id = app_handle.config().identifier.clone();
-    match get_credential(DEEPL_SERVICE, &app_id) {
         Ok(_) => true,
         Err(_) => false,
     }

--- a/src-tauri/src/language_service.rs
+++ b/src-tauri/src/language_service.rs
@@ -176,3 +176,4 @@ pub async fn check_grammar(
 
     Ok(result)
 }
+

--- a/src-tauri/src/language_service.rs
+++ b/src-tauri/src/language_service.rs
@@ -1,0 +1,178 @@
+use crate::credential_manager;
+use log::{debug, error};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::{command, AppHandle, Manager};
+
+const LT_DEFAULT_ENDPOINT: &str = "https://api.languagetoolplus.com/v2/check";
+const LANGUAGETOOL_SERVICE: &str = "jot.languagetool";
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LtReplacement {
+    pub value: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LtRule {
+    pub id: String,
+    pub description: String,
+    #[serde(rename = "issueType")]
+    pub issue_type: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LtMatch {
+    pub message: String,
+    pub offset: usize,
+    pub length: usize,
+    pub replacements: Vec<LtReplacement>,
+    pub rule: LtRule,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GrammarCheckResult {
+    pub matches: Vec<LtMatch>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LanguageServicesConfig {
+    pub languagetool_endpoint: String,
+    pub languagetool_username: Option<String>,
+    pub languagetool_api_key: Option<String>,
+}
+
+fn get_settings_path(app_handle: &AppHandle) -> PathBuf {
+    let app_dir = app_handle
+        .path()
+        .app_data_dir()
+        .expect("Failed to get app data directory");
+    if !app_dir.exists() {
+        fs::create_dir_all(&app_dir).expect("Failed to create app data directory");
+    }
+    app_dir.join("settings.json")
+}
+
+fn read_settings(app_handle: &AppHandle) -> serde_json::Value {
+    let path = get_settings_path(app_handle);
+    if path.exists() {
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(json) = serde_json::from_str(&content) {
+                return json;
+            }
+        }
+    }
+    serde_json::json!({})
+}
+
+fn write_settings(app_handle: &AppHandle, settings: &serde_json::Value) -> Result<(), String> {
+    let path = get_settings_path(app_handle);
+    let json_str = serde_json::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
+    fs::write(path, json_str).map_err(|e| format!("Failed to write settings: {}", e))
+}
+
+#[command]
+pub fn get_language_services_config(
+    app_handle: AppHandle,
+) -> Result<LanguageServicesConfig, String> {
+    let settings = read_settings(&app_handle);
+    let endpoint = settings["lt_endpoint"]
+        .as_str()
+        .unwrap_or(LT_DEFAULT_ENDPOINT)
+        .to_string();
+    let username = settings["lt_username"].as_str().map(|s| s.to_string());
+
+    // Indicate if API key is stored (without exposing the key itself)
+    let has_key = username.as_deref().map_or(false, |uname| {
+        credential_manager::get_credential(LANGUAGETOOL_SERVICE, uname).is_ok()
+    });
+
+    Ok(LanguageServicesConfig {
+        languagetool_endpoint: endpoint,
+        languagetool_username: username,
+        languagetool_api_key: if has_key {
+            Some("stored".to_string())
+        } else {
+            None
+        },
+    })
+}
+
+#[command]
+pub fn save_language_tool_config(
+    app_handle: AppHandle,
+    username: Option<String>,
+    api_key: Option<String>,
+    endpoint: Option<String>,
+) -> Result<(), String> {
+    let mut settings = read_settings(&app_handle);
+
+    if let Some(ref ep) = endpoint {
+        settings["lt_endpoint"] = serde_json::json!(ep);
+    }
+    if let Some(ref uname) = username {
+        settings["lt_username"] = serde_json::json!(uname);
+    }
+
+    write_settings(&app_handle, &settings)?;
+
+    if let (Some(ref uname), Some(ref key)) = (&username, &api_key) {
+        credential_manager::store_credential(LANGUAGETOOL_SERVICE, uname, key)?;
+    }
+
+    Ok(())
+}
+
+#[command]
+pub async fn check_grammar(
+    app_handle: AppHandle,
+    text: String,
+    language: String,
+) -> Result<GrammarCheckResult, String> {
+    let settings = read_settings(&app_handle);
+    let endpoint = settings["lt_endpoint"]
+        .as_str()
+        .unwrap_or(LT_DEFAULT_ENDPOINT)
+        .to_string();
+    let username = settings["lt_username"].as_str().map(|s| s.to_string());
+
+    let client = Client::new();
+    let mut params: Vec<(String, String)> = vec![
+        ("text".to_string(), text),
+        ("language".to_string(), language),
+    ];
+
+    if let Some(ref uname) = username {
+        if let Ok(api_key) = credential_manager::get_credential(LANGUAGETOOL_SERVICE, uname) {
+            params.push(("username".to_string(), uname.clone()));
+            params.push(("apiKey".to_string(), api_key));
+        }
+    }
+
+    debug!("Grammar check via {}", endpoint);
+
+    let response = client
+        .post(&endpoint)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        error!("LanguageTool API error {}: {}", status, body);
+        return Err(format!("API error {}: {}", status, body));
+    }
+
+    let result: GrammarCheckResult = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    debug!("Grammar check: {} matches", result.matches.len());
+
+    Ok(result)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,8 @@ use tauri::{App, AppHandle, Manager};
 
 mod backup_service;
 mod credential_manager;
-    mod logging;
+mod language_service;
+mod logging;
 mod storage_service;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -279,12 +280,12 @@ pub fn run() {
             credential_manager::store_languagetool_credential,
             credential_manager::get_languagetool_credential,
             credential_manager::has_languagetool_credential,
-            credential_manager::store_deepl_credential,
-            credential_manager::get_deepl_credential,
-            credential_manager::has_deepl_credential,
             credential_manager::store_chatgpt_credential,
             credential_manager::get_chatgpt_credential,
             credential_manager::has_chatgpt_credential,
+            language_service::get_language_services_config,
+            language_service::save_language_tool_config,
+            language_service::check_grammar,
             storage_service::get_storage_settings,
             storage_service::set_storage_path
         ])

--- a/src/lib/components/BackupSettings.svelte
+++ b/src/lib/components/BackupSettings.svelte
@@ -188,6 +188,8 @@
             <div class="grid grid-cols-1 gap-2 mb-4">
                 {#each $backups as backup}
                     <div
+                        role="button"
+                        tabindex="0"
                         class="p-3 border rounded-md flex justify-between items-center cursor-pointer transition-colors"
                         class:bg-gray-50={$selectedBackupPath !== backup.path}
                         class:dark:bg-gray-800={$selectedBackupPath !==
@@ -206,6 +208,7 @@
                         class:dark:border-blue-700={$selectedBackupPath ===
                             backup.path}
                         on:click={() => selectedBackupPath.set(backup.path)}
+                        on:keydown={(e) => e.key === "Enter" && selectedBackupPath.set(backup.path)}
                     >
                         <div>
                             <div

--- a/src/lib/components/LanguageSettings.svelte
+++ b/src/lib/components/LanguageSettings.svelte
@@ -6,7 +6,6 @@
     languageConfig,
     loadLanguageServicesConfig,
     saveLanguageToolConfig,
-    saveDeepLConfig,
   } from "$lib/stores/languageServices";
   import Button from "./Button.svelte";
   import FormField from "./FormField.svelte";
@@ -17,29 +16,20 @@
   let languagetoolApiKey: string = "";
   let languagetoolUsername: string = "";
   let languagetoolEndpoint: string = "";
-  let deeplApiKey: string = "";
-  let deeplEndpoint: string = "";
-  let languageToolStatus: boolean = false;
-  let deeplStatus: boolean = false;
+  let hasStoredApiKey: boolean = false;
 
   // Success/error messages
   let ltSaveSuccess: boolean = false;
   let ltSaveError: string | null = null;
-  let deeplSaveSuccess: boolean = false;
-  let deeplSaveError: string | null = null;
-  let ltSaveTimeout: number | null = null;
-  let deeplSaveTimeout: number | null = null;
+  let ltSaveTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Load current configuration
   onMount(async () => {
     await loadLanguageServicesConfig();
 
     if ($languageConfig) {
-      languagetoolApiKey = $languageConfig.languagetool_api_key || "";
       languagetoolUsername = $languageConfig.languagetool_username || "";
       languagetoolEndpoint = $languageConfig.languagetool_endpoint;
-      deeplApiKey = $languageConfig.deepl_api_key || "";
-      deeplEndpoint = $languageConfig.deepl_endpoint;
     }
 
     await checkCredentialStatus();
@@ -48,7 +38,6 @@
   // Clear timeouts on destroy
   onDestroy(() => {
     if (ltSaveTimeout) clearTimeout(ltSaveTimeout);
-    if (deeplSaveTimeout) clearTimeout(deeplSaveTimeout);
   });
 
   // Save LanguageTool configuration
@@ -77,53 +66,20 @@
     }
   }
 
-  // Save DeepL configuration
-  async function handleSaveDeepLConfig() {
-    deeplSaveSuccess = false;
-    deeplSaveError = null;
-
-    try {
-      const success = await saveDeepLConfig(
-        deeplApiKey || undefined,
-        deeplEndpoint
-      );
-
-      if (success) {
-        deeplSaveSuccess = true;
-        if (deeplSaveTimeout) clearTimeout(deeplSaveTimeout);
-        deeplSaveTimeout = setTimeout(() => {
-          deeplSaveSuccess = false;
-        }, 3000);
-      } else {
-        deeplSaveError = "Failed to save settings";
-      }
-    } catch (error) {
-      deeplSaveError = `Error: ${error}`;
+  async function checkCredentialStatus() {
+    if (languagetoolUsername) {
+      const hasCredential = await invoke<boolean>(SettingsCommands.HAS_LANGUAGETOOL_API_KEY, { username: languagetoolUsername });
+      hasStoredApiKey = !!hasCredential;
+      languagetoolApiKey = "";
     }
   }
-
-  async function checkCredentialStatus() {
-  // For LanguageTool
-  if (languagetoolUsername) {
-    const hasCredential = await invoke(SettingsCommands.HAS_LANGUAGETOOL_API_KEY, { username: languagetoolUsername });
-    console.log("LanguageTool credential status:", hasCredential);
-    languagetoolApiKey = hasCredential ? 'default' : '';
-  }
-  
-  // For DeepL
-  const hasDeeplCredential = await invoke('has_deepl_credential');
-  console.log("DeepL credential status:", hasDeeplCredential);
-  deeplApiKey = hasDeeplCredential ? 'default' : '';
-}
 
   // Reset to default configuration
   function resetLTDefaults() {
     languagetoolEndpoint = "https://api.languagetoolplus.com/v2/check";
   }
 
-  function resetDeepLDefaults() {
-    deeplEndpoint = "https://api-free.deepl.com/v2/translate";
-  }
+
 </script>
 
 <div class="space-y-6">
@@ -159,10 +115,17 @@
           id="lt-api-key"
           type="password"
           bind:value={languagetoolApiKey}
-          placeholder="Enter your LanguageTool API key"
+          placeholder={hasStoredApiKey ? "Neuen Key eingeben um zu ersetzen" : "LanguageTool API Key eingeben"}
           label="API Key"
         />
-        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Used together with username for authentication</p>
+        {#if hasStoredApiKey}
+          <p class="mt-1 text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+            <FontAwesomeIcon icon="check-circle" />
+            API Key gespeichert – Feld leer lassen um beizubehalten
+          </p>
+        {:else}
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Wird zusammen mit dem Benutzernamen für die Authentifizierung verwendet</p>
+        {/if}
       </div>
 
       <div>
@@ -219,81 +182,6 @@
           <li>Enter both username and API key for premium access</li>
           <li>Your username is usually your registered email</li>
         </ul>
-      </div>
-    </div>
-  </section>
-
-  <!-- DeepL Configuration Section -->
-  <section class="pt-2">
-    <h3 class="text-lg font-medium text-gray-800 dark:text-gray-200 mb-2">DeepL Configuration</h3>
-    <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
-      Configure DeepL API for translation services.
-      <a
-        href="https://www.deepl.com/pro#developer"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-blue-600 dark:text-blue-400 hover:underline"
-      >
-        Get API key
-      </a>
-    </p>
-
-    <div class="space-y-4">
-      <div>
-        <FormField
-          id="deepl-api-key"
-          type="password"
-          bind:value={deeplApiKey}
-          placeholder="Enter your DeepL API key (required)"
-          label="API Key"
-        />
-        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          API key is required for translation functionality
-        </p>
-      </div>
-
-      <div>
-        <label for="deepl-endpoint" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">API Endpoint</label>
-        <div class="flex gap-2">
-          <input
-            type="text"
-            id="deepl-endpoint"
-            bind:value={deeplEndpoint}
-            placeholder="https://api-free.deepl.com/v2/translate"
-            class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          <button
-            class="p-2 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors"
-            on:click={resetDeepLDefaults}
-            title="Reset to default"
-          >
-            <FontAwesomeIcon icon="undo" />
-          </button>
-        </div>
-      </div>
-
-      <div class="flex items-center gap-3 mt-4">
-        <Button 
-          variant="primary" 
-          icon="save" 
-          on:click={handleSaveDeepLConfig}
-        >
-          Save DeepL Settings
-        </Button>
-
-        {#if deeplSaveSuccess}
-          <div class="text-green-600 dark:text-green-400 flex items-center">
-            <FontAwesomeIcon icon="check-circle" class="mr-1" />
-            <span class="text-sm">Settings saved</span>
-          </div>
-        {/if}
-
-        {#if deeplSaveError}
-          <div class="text-red-600 dark:text-red-400 flex items-center">
-            <FontAwesomeIcon icon="exclamation-circle" class="mr-1" />
-            <span class="text-sm">{deeplSaveError}</span>
-          </div>
-        {/if}
       </div>
     </div>
   </section>

--- a/src/lib/components/LinkModal.svelte
+++ b/src/lib/components/LinkModal.svelte
@@ -18,7 +18,13 @@
     });
 </script>
 
-<div class="modal-backdrop" on:click={cancel}></div>
+<div
+    class="modal-backdrop"
+    role="button"
+    tabindex="-1"
+    on:click={cancel}
+    on:keydown={(e) => e.key === "Escape" && cancel()}
+></div>
 <div class="modal">
     <form on:submit|preventDefault={submit}>
         <label>

--- a/src/lib/components/MarkdownEditor.svelte
+++ b/src/lib/components/MarkdownEditor.svelte
@@ -214,9 +214,19 @@
             btn.textContent = r.value;
             btn.onmousedown = (e) => {
               e.preventDefault();
+              const { errors } = view.state.field(spellErrorField);
+              const changes = view.state.changes({ from: match.from, to: match.to, insert: r.value });
+              const remaining = errors
+                .filter((err) => err.from !== match.from || err.to !== match.to)
+                .map((err) => ({
+                  ...err,
+                  from: changes.mapPos(err.from),
+                  to: changes.mapPos(err.to, 1),
+                }))
+                .filter((err) => err.from < err.to);
               view.dispatch({
                 changes: { from: match.from, to: match.to, insert: r.value },
-                effects: setSpellErrors.of([]),
+                effects: setSpellErrors.of(remaining),
               });
             };
             dom.appendChild(btn);
@@ -235,6 +245,7 @@
   function buildSpellCheckExtensions() {
     return [spellErrorField, spellCheckPlugin, spellHoverTooltip];
   }
+
 
   // --- Zeilen-Hervorhebung nach Tab-Wechsel ---
   const setHighlightLine = StateEffect.define<number | null>();

--- a/src/lib/components/MarkdownEditor.svelte
+++ b/src/lib/components/MarkdownEditor.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { onMount, onDestroy, createEventDispatcher } from "svelte";
+  import { get } from "svelte/store";
   import {
     EditorView,
     ViewPlugin,
     keymap,
     Decoration,
+    hoverTooltip,
     type DecorationSet,
     type ViewUpdate,
   } from "@codemirror/view";
@@ -21,8 +23,10 @@
     historyKeymap,
   } from "@codemirror/commands";
   import { tags } from "@lezer/highlight";
+  import { invoke } from "@tauri-apps/api/core";
   import { open } from "@tauri-apps/plugin-shell";
   import { theme, fontSize } from "$lib/stores/settings";
+  import { spellCheckEnabled, type GrammarError } from "$lib/stores/languageServices";
   import { activeTab } from "$lib/stores/tabs";
   import { notes, updateNote } from "$lib/stores/notes";
   import { tabColors } from "$lib/utils/colors";
@@ -82,6 +86,156 @@
     { decorations: (v) => v.decorations }
   );
 
+  // --- Spell-Check via LanguageTool ---
+
+  interface SpellError {
+    from: number;
+    to: number;
+    error: GrammarError;
+  }
+
+  interface SpellState {
+    decorations: DecorationSet;
+    errors: SpellError[];
+  }
+
+  const setSpellErrors = StateEffect.define<SpellError[]>();
+
+  const spellErrorField = StateField.define<SpellState>({
+    create: () => ({ decorations: Decoration.none, errors: [] }),
+    update(state, tr) {
+      let decorations = state.decorations.map(tr.changes);
+      let errors = state.errors
+        .map((e) => ({
+          ...e,
+          from: tr.changes.mapPos(e.from),
+          to: tr.changes.mapPos(e.to, 1),
+        }))
+        .filter((e) => e.from < e.to);
+
+      for (const effect of tr.effects) {
+        if (effect.is(setSpellErrors)) {
+          const newErrors = effect.value;
+          const builder = new RangeSetBuilder<Decoration>();
+          for (const { from, to } of newErrors.sort((a, b) => a.from - b.from)) {
+            if (from < to) {
+              builder.add(from, to, Decoration.mark({ class: "cm-spell-error" }));
+            }
+          }
+          decorations = builder.finish();
+          errors = newErrors;
+        }
+      }
+
+      return { decorations, errors };
+    },
+    provide: (f) => EditorView.decorations.from(f, (s) => s.decorations),
+  });
+
+  const spellCheckPlugin = ViewPlugin.fromClass(
+    class {
+      private timer: ReturnType<typeof setTimeout> | null = null;
+      private view: EditorView;
+
+      constructor(view: EditorView) {
+        this.view = view;
+        this.scheduleCheck();
+      }
+
+      update(update: ViewUpdate) {
+        if (update.docChanged) this.scheduleCheck();
+      }
+
+      scheduleCheck() {
+        if (this.timer) clearTimeout(this.timer);
+        this.timer = setTimeout(() => this.runCheck(), 1500);
+      }
+
+      async runCheck() {
+        const text = this.view.state.doc.toString();
+        if (!text.trim()) {
+          this.view.dispatch({ effects: setSpellErrors.of([]) });
+          return;
+        }
+        try {
+          const result = await invoke<{ matches: GrammarError[] }>("check_grammar", {
+            text,
+            language: "auto",
+          });
+          if (!this.view.dom.isConnected) return;
+          const errors: SpellError[] = result.matches.map((m) => ({
+            from: m.offset,
+            to: m.offset + m.length,
+            error: m,
+          }));
+          this.view.dispatch({ effects: setSpellErrors.of(errors) });
+        } catch (e) {
+          logger.error("Spell check failed", String(e));
+        }
+      }
+
+      destroy() {
+        if (this.timer) clearTimeout(this.timer);
+      }
+    }
+  );
+
+  const spellHoverTooltip = hoverTooltip(
+    (view, pos) => {
+    if (!view.state.field(spellErrorField, false)) return null;
+    const { errors } = view.state.field(spellErrorField);
+    const match = errors.find((e) => pos >= e.from && pos <= e.to);
+    if (!match) return null;
+
+    return {
+      pos: match.from,
+      end: match.to,
+      above: true,
+      create() {
+        const isDark = !!document.querySelector(".dark");
+        const dom = document.createElement("div");
+        dom.className = "cm-spell-tooltip";
+        dom.style.cssText = isDark
+          ? "background:#2d2d2d;color:#e0e0e0;border-color:rgba(255,255,255,0.12)"
+          : "background:#fff;color:#1a1a1a;border-color:rgba(0,0,0,0.12)";
+
+        if (match.error.replacements.length === 0) {
+          const none = document.createElement("span");
+          none.className = "cm-spell-tooltip-empty";
+          none.textContent = match.error.message;
+          dom.appendChild(none);
+        } else {
+          match.error.replacements.slice(0, 5).forEach((r) => {
+            const btn = document.createElement("button");
+            btn.className = "cm-spell-suggestion";
+            btn.style.cssText = isDark
+              ? "border-color:rgba(255,255,255,0.18);color:#e0e0e0"
+              : "border-color:rgba(0,0,0,0.15);color:#1a1a1a";
+            btn.textContent = r.value;
+            btn.onmousedown = (e) => {
+              e.preventDefault();
+              view.dispatch({
+                changes: { from: match.from, to: match.to, insert: r.value },
+                effects: setSpellErrors.of([]),
+              });
+            };
+            dom.appendChild(btn);
+          });
+        }
+
+        return { dom };
+      },
+    };
+  },
+  {
+    hideOn: (tr) => tr.effects.some((e) => e.is(setSpellErrors)),
+  }
+  );
+
+  function buildSpellCheckExtensions() {
+    return [spellErrorField, spellCheckPlugin, spellHoverTooltip];
+  }
+
   // --- Zeilen-Hervorhebung nach Tab-Wechsel ---
   const setHighlightLine = StateEffect.define<number | null>();
 
@@ -125,6 +279,7 @@
 
   const highlightCompartment = new Compartment();
   const editorThemeCompartment = new Compartment();
+  const spellCheckCompartment = new Compartment();
 
   function buildHighlightStyle() {
     const isDark = $theme === "dark";
@@ -263,6 +418,15 @@
     const _t = $theme;
     const _f = $fontSize;
     if (view && (_t || _f)) reconfigureEditor();
+  }
+
+  // Toggle spell check on/off
+  $: if (view) {
+    view.dispatch({
+      effects: spellCheckCompartment.reconfigure(
+        $spellCheckEnabled ? buildSpellCheckExtensions() : []
+      ),
+    });
   }
 
   // --- Markdown formatting helpers ---
@@ -425,6 +589,7 @@
           highlightLineField,
           highlightCompartment.of(syntaxHighlighting(buildHighlightStyle())),
           editorThemeCompartment.of(buildEditorTheme()),
+          spellCheckCompartment.of([]),
           history(),
           EditorView.lineWrapping,
           EditorView.updateListener.of(handleUpdate),
@@ -449,6 +614,23 @@
                   }
                   break;
                 }
+                if (node.name === "Link" || node.name === "Image") {
+                  let child = node.firstChild;
+                  while (child) {
+                    if (child.name === "URL") {
+                      const href = editorView.state.sliceDoc(child.from, child.to);
+                      if (/^https?:\/\/|^mailto:/i.test(href)) {
+                        event.preventDefault();
+                        open(href).catch((e) =>
+                          logger.error("Failed to open URL", e)
+                        );
+                        return true;
+                      }
+                    }
+                    child = child.nextSibling;
+                  }
+                  break;
+                }
                 if (!node.parent) break;
                 node = node.parent;
               }
@@ -470,6 +652,13 @@
       }),
       parent: editorContainer,
     });
+
+    // Initialize spell check if it was previously enabled
+    if (get(spellCheckEnabled)) {
+      view.dispatch({
+        effects: spellCheckCompartment.reconfigure(buildSpellCheckExtensions()),
+      });
+    }
 
     requestAnimationFrame(() => restorePositions());
   });
@@ -522,5 +711,44 @@
     0%   { background-color: rgba(255, 200, 80, 0.28); }
     40%  { background-color: rgba(255, 200, 80, 0.18); }
     100% { background-color: transparent; }
+  }
+
+  :global(.cm-spell-error) {
+    text-decoration: underline wavy red;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  :global(.cm-spell-tooltip) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 6px 8px;
+    max-width: 280px;
+    background: var(--cm-tooltip-bg, #fff);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  }
+
+  :global(.cm-spell-suggestion) {
+    padding: 2px 8px;
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.88em;
+    color: inherit;
+    transition: background 0.1s;
+  }
+
+  :global(.cm-spell-suggestion:hover) {
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  :global(.cm-spell-tooltip-empty) {
+    font-size: 0.85em;
+    opacity: 0.7;
+    font-style: italic;
   }
 </style>

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -2,6 +2,7 @@
   import { createBackup, loadBackups } from "$lib/stores/backupStore";
   import { notes } from "$lib/stores/notes";
   import { theme, toggleTheme } from "$lib/stores/settings";
+  import { spellCheckEnabled, toggleSpellCheck } from "$lib/stores/languageServices";
   import { activeTab } from "$lib/stores/tabs";
   import { activeTabBackground } from "$lib/stores/tabStyles";
   import { emptyTabColor, tabColors } from "$lib/utils/colors";
@@ -120,6 +121,16 @@
       </div>
     {/if}
 
+    <!-- Spell check toggle -->
+    <button
+      class="w-8 h-8 rounded-full flex items-center justify-center hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+      class:text-blue-500={$spellCheckEnabled}
+      on:click={toggleSpellCheck}
+      title="Rechtschreibprüfung {$spellCheckEnabled ? '(an)' : '(aus)'}"
+    >
+      <FontAwesomeIcon icon="spell-check" />
+    </button>
+
     <!-- Backup button -->
     <button
       class="w-8 h-8 rounded-full flex items-center justify-center hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
@@ -156,19 +167,4 @@
 <Help bind:this={helpComponent} />
 
 <style>
-  /* Custom animation for dropdown menus */
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(5px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  .animate-fadeIn {
-    animation: fadeIn 0.2s ease-out;
-  }
 </style>

--- a/src/lib/components/UnifiedSettings.svelte
+++ b/src/lib/components/UnifiedSettings.svelte
@@ -11,6 +11,7 @@
     import Button from "./Button.svelte";
     import BackupSettings from "./BackupSettings.svelte";
     import StorageSettings from "./StorageSettings.svelte";
+    import LanguageSettings from "./LanguageSettings.svelte";
     import { getVersion } from "@tauri-apps/api/app";
     import { onMount } from "svelte";
 
@@ -27,7 +28,7 @@
     ];
 
     // Settings tabs
-    type SettingsTab = "appearance" | "storage" | "backups" | "about";
+    type SettingsTab = "appearance" | "storage" | "backups" | "language" | "about";
     let activeTab: SettingsTab = "appearance";
 
     function changeFontSize(size: FontSize) {
@@ -74,6 +75,17 @@
                     <FontAwesomeIcon icon="archive" class="sidebar-icon" />
                 </div>
                 <span>Backups</span>
+            </button>
+
+            <button
+                class="sidebar-tab"
+                class:active={activeTab === "language"}
+                on:click={() => setActiveTab("language")}
+            >
+                <div class="sidebar-icon">
+                    <FontAwesomeIcon icon="language" class="sidebar-icon" />
+                </div>
+                <span>Language</span>
             </button>
 
             <button
@@ -154,10 +166,10 @@
             </div>
         {/if}
 
-        <!-- Logs tab -->
-        {#if activeTab === "logs"}
+        <!-- Language tab -->
+        {#if activeTab === "language"}
             <div class="tab-content">
-                <LogSettings />
+                <LanguageSettings />
             </div>
         {/if}
 

--- a/src/lib/fa-icons.ts
+++ b/src/lib/fa-icons.ts
@@ -36,6 +36,7 @@ import {
   faRobot,
   faBrain,
   faMagic,
+  faSpellCheck,
 } from "@fortawesome/free-solid-svg-icons";
 
 // Add all icons to the library
@@ -74,5 +75,6 @@ library.add(
   faFileImport,
   faRobot,
   faBrain,
-  faMagic
+  faMagic,
+  faSpellCheck
 );

--- a/src/lib/stores/languageServices.ts
+++ b/src/lib/stores/languageServices.ts
@@ -1,8 +1,6 @@
-// $lib/stores/languageServices.ts
 import { writable, get } from "svelte/store";
 import { invoke } from "@tauri-apps/api/core";
 
-// Define types for grammar checking
 export interface GrammarError {
   message: string;
   offset: number;
@@ -19,76 +17,65 @@ export interface GrammarCheckResult {
   matches: GrammarError[];
 }
 
-// Define types for translation
-export interface TranslationResult {
-  translations: {
-    detected_source_language: string;
-    text: string;
-  }[];
-}
-
-// Language service configuration
 export interface LanguageServicesConfig {
   languagetool_api_key: string | null;
-  languagetool_username: string | null; // Added username field
+  languagetool_username: string | null;
   languagetool_endpoint: string;
-  deepl_api_key: string | null;
-  deepl_endpoint: string;
 }
 
-// Store for language service configuration
 export const languageConfig = writable<LanguageServicesConfig>({
   languagetool_api_key: null,
-  languagetool_username: null, // Added username field
+  languagetool_username: null,
   languagetool_endpoint: "https://api.languagetoolplus.com/v2/check",
-  deepl_api_key: null,
-  deepl_endpoint: "https://api-free.deepl.com/v2/translate",
 });
 
-// Store for grammar check results
-export const grammarCheckResults = writable<GrammarCheckResult>({
-  matches: [],
-});
-
-// Store for translation results
-export const translationResult = writable<string>("");
-
-// Store for language service states
 export const isGrammarCheckInProgress = writable<boolean>(false);
-export const isTranslationInProgress = writable<boolean>(false);
 export const grammarCheckError = writable<string | null>(null);
-export const translationError = writable<string | null>(null);
+export const grammarCheckResults = writable<GrammarCheckResult>({ matches: [] });
 
-// Load language services configuration
+// Spell check toggle — persisted to localStorage
+export const spellCheckEnabled = writable<boolean>(
+  typeof localStorage !== "undefined"
+    ? localStorage.getItem("jot-spell-check") === "true"
+    : false
+);
+
+if (typeof localStorage !== "undefined") {
+  spellCheckEnabled.subscribe((val) => {
+    localStorage.setItem("jot-spell-check", String(val));
+  });
+}
+
+export function toggleSpellCheck() {
+  spellCheckEnabled.update((v) => !v);
+}
+
 export async function loadLanguageServicesConfig(): Promise<void> {
   try {
     const config = await invoke<LanguageServicesConfig>(
       "get_language_services_config"
     );
     languageConfig.set(config);
-    return;
   } catch (error) {
     console.error("Failed to load language services config:", error);
   }
 }
 
-// Save LanguageTool configuration
 export async function saveLanguageToolConfig(
   apiKey?: string,
-  username?: string, // Added username parameter
+  username?: string,
   endpoint?: string
 ): Promise<boolean> {
   try {
     await invoke("save_language_tool_config", {
       apiKey,
-      username, // Added username parameter
+      username,
       endpoint,
     });
 
-    // Update local store
     languageConfig.update((config) => ({
       ...config,
-      languagetool_username: username ?? config.languagetool_username, // Added username update
+      languagetool_username: username ?? config.languagetool_username,
       languagetool_endpoint: endpoint ?? config.languagetool_endpoint,
     }));
 
@@ -99,34 +86,9 @@ export async function saveLanguageToolConfig(
   }
 }
 
-// Save DeepL configuration
-export async function saveDeepLConfig(
-  apiKey?: string,
-  endpoint?: string
-): Promise<boolean> {
-  try {
-    await invoke("save_deepl_config", {
-      apiKey,
-      endpoint,
-    });
-
-    // Update local store
-    languageConfig.update((config) => ({
-      ...config,
-      deepl_endpoint: endpoint ?? config.deepl_endpoint,
-    }));
-
-    return true;
-  } catch (error) {
-    console.error("Failed to save DeepL config:", error);
-    return false;
-  }
-}
-
-// Check grammar with LanguageTool
 export async function checkGrammar(
   text: string,
-  language: string = "en-US"
+  language: string = "auto"
 ): Promise<GrammarCheckResult> {
   if (!text.trim()) {
     return { matches: [] };
@@ -153,51 +115,7 @@ export async function checkGrammar(
   }
 }
 
-// Translate text with DeepL
-export async function translateText(
-  text: string,
-  targetLang: string,
-  sourceLang?: string
-): Promise<string> {
-  if (!text.trim()) {
-    return "";
-  }
-
-  isTranslationInProgress.set(true);
-  translationError.set(null);
-
-  try {
-    const result = await invoke<TranslationResult>("translate_text", {
-      text,
-      targetLang,
-      sourceLang,
-    });
-
-    if (result.translations && result.translations.length > 0) {
-      const translatedText = result.translations[0].text;
-      translationResult.set(translatedText);
-      return translatedText;
-    }
-
-    return "";
-  } catch (error) {
-    const errorMessage = `Translation failed: ${error}`;
-    console.error(errorMessage);
-    translationError.set(errorMessage);
-    return "";
-  } finally {
-    isTranslationInProgress.set(false);
-  }
-}
-
-// Clear grammar check results
 export function clearGrammarCheckResults(): void {
   grammarCheckResults.set({ matches: [] });
   grammarCheckError.set(null);
-}
-
-// Clear translation results
-export function clearTranslationResults(): void {
-  translationResult.set("");
-  translationError.set(null);
 }

--- a/src/lib/utils/tauriCommands.ts
+++ b/src/lib/utils/tauriCommands.ts
@@ -14,7 +14,6 @@ export namespace SettingsCommands {
   export const LOAD_SETTINGS: string = "load_settings";
   export const SAVE_ACTIVE_TAB: string = "save_active_tab";
   export const HAS_LANGUAGETOOL_API_KEY: string = "has_languagetool_credential";
-  export const HAS_DEEPL_API_KEY: string = "has_deepl_credential";
 }
 
 export namespace NotesCommands {


### PR DESCRIPTION
## Summary

- Integriert LanguageTool Grammatik- und Rechtschreibprüfung in den CodeMirror-Editor
- Falsch geschriebene/grammatikalisch fehlerhafte Wörter werden rot wellig unterstrichen
- Hover-Tooltip zeigt Korrekturvorschläge; Klick ersetzt das Wort (andere Unterstreichungen bleiben erhalten)
- Toggle-Button in der Statusleiste (unten rechts) zum Ein-/Ausschalten; Zustand wird in localStorage gespeichert
- LanguageTool-Einstellungen (API-Key, Username, Endpoint) in den App-Settings konfigurierbar
- API-Key wird sicher im System-Keychain gespeichert
- DeepL-Integration vollständig entfernt

## Test plan

- [ ] Spell-Check-Toggle in Statusleiste aktivieren
- [ ] Text mit Fehler eingeben → rote Unterstreichung erscheint nach ~1,5s
- [ ] Über unterstrichenes Wort hovern → Tooltip mit Vorschlägen
- [ ] Vorschlag klicken → Wort ersetzt, nur diese Unterstreichung entfernt, andere bleiben
- [ ] LanguageTool API-Key in Settings > Language hinterlegen
- [ ] Ohne API-Key: Public API funktioniert trotzdem (limitiertes Rate-Limit)
- [ ] Dark Mode: Tooltip lesbar (dunkler Hintergrund)

🤖 Generated with [Claude Code](https://claude.com/claude-code)